### PR TITLE
Fixed tuple optimization error for cython 0.22

### DIFF
--- a/pyspades/common.pyx
+++ b/pyspades/common.pyx
@@ -139,7 +139,11 @@ cdef class Vertex3:
         return create_vertex3(self.value.x, self.value.y, self.value.z)
     
     def get(self):
-        return self.value.x, self.value.y, self.value.z
+        # temp vars are needed to disable cython tuple optimization
+        tmp_x = self.value.x
+        tmp_y = self.value.y
+        tmp_z = self.value.z
+        return tmp_x, tmp_y, tmp_z
     
     def set(self, float x, float y, float z):
         self.value.x = x
@@ -258,8 +262,14 @@ cdef class Vertex3:
     def normalize(self):
         cdef float k = self.length()
         cdef Vector * a = self.value
-        a.x, a.y, a.z = (k and (a.x / k, a.y / k, a.z / k) or
-            (0.0, 0.0, 0.0))
+        if k:
+            a.x /= k
+            a.y /= k
+            a.z /= k
+        else:
+            a.x = 0
+            a.y = 0
+            a.z = 0
         return k
     
     cpdef Quaternion get_rotation_to(self, Vertex3 A):


### PR DESCRIPTION
My compiler gives me an error when I'm compiling with cython 0.22.
```
running build_ext
building 'pyspades.common' extension
gcc -pthread -fno-strict-aliasing -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong --param=ssp-buffer-size=4 -DNDEBUG -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong --param=ssp-buffer-size=4 -fPIC -I./pyspades -I./include -I/usr/include/python2.7 -c ./pyspades/common.cpp -o build/temp.linux-x86_64-2.7/./pyspades/common.o
./pyspades/common.cpp: In function ‘PyObject* __pyx_pf_8pyspades_6common_7Vertex3_50normalize(__pyx_obj_8pyspades_6common_Vertex3*)’:
./pyspades/common.cpp:6385:7: error: no match for ‘operator!’ (operand type is ‘__pyx_ctuple_float__and_float__and_float’)
   if (!__pyx_t_6) {
       ^
./pyspades/common.cpp:6385:7: note: candidate is:
./pyspades/common.cpp:6385:7: note: operator!(bool) <built-in>
./pyspades/common.cpp:6385:7: note:   no known conversion for argument 1 from ‘__pyx_ctuple_float__and_float__and_float’ to ‘bool’
error: command 'gcc' failed with exit status 1
running build_ext
skipping 'enet.c' Cython extension (up-to-date)
```
These trivial edits eliminates the error.