### PR TITLE
Add notice of no longer being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# NOTE:
+
+Pysnip is no longer being maintained. For a currently maintained fork of PySnip, see https://github.com/piqueserver/piqueserver.
+
 ![PySnip](http://i.imgur.com/QFgqcRM.png)
 
 [![Build Status](https://travis-ci.org/NateShoffner/PySnip.svg?branch=master)](https://travis-ci.org/NateShoffner/PySnip)


### PR DESCRIPTION
This project has not been actively maintained for years, however people unaware of this are still using it. This header in the readme redirects them to the currently maintained project.

I hope you have the time to at least merge this last pull-request.

I'd recommend also adding a notice to the repo description, as well as archiving the repository to make it clear that this repository is no longer active.